### PR TITLE
Implement 3rd party block creation (#104)

### DIFF
--- a/src/main/java/org/biscuitsec/biscuit/crypto/KeyPair.java
+++ b/src/main/java/org/biscuitsec/biscuit/crypto/KeyPair.java
@@ -2,12 +2,17 @@ package org.biscuitsec.biscuit.crypto;
 
 
 import biscuit.format.schema.Schema;
+import biscuit.format.schema.Schema.PublicKey.Algorithm;
+import net.i2p.crypto.eddsa.EdDSAEngine;
 import org.biscuitsec.biscuit.token.builder.Utils;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import net.i2p.crypto.eddsa.spec.*;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.Signature;
 
 /**
  * Private and public key
@@ -37,6 +42,26 @@ public final class KeyPair {
 
         this.private_key = privKey;
         this.public_key = pubKey;
+    }
+
+    public static KeyPair generate(Algorithm algorithm) {
+        return generate(algorithm, new SecureRandom());
+    }
+
+    public static KeyPair generate(Algorithm algorithm, SecureRandom rng) {
+        if (algorithm == Algorithm.Ed25519) {
+            return new KeyPair(rng);
+        } else {
+            throw new IllegalArgumentException("Unsupported algorithm");
+        }
+    }
+
+    public static Signature generateSignature(Algorithm algorithm) throws NoSuchAlgorithmException {
+        if (algorithm == Algorithm.Ed25519) {
+            return KeyPair.getSignature();
+        } else {
+            throw new NoSuchAlgorithmException("Unsupported algorithm");
+        }
     }
 
     public byte[] toBytes() {
@@ -69,6 +94,10 @@ public final class KeyPair {
 
         this.private_key = privKey;
         this.public_key = pubKey;
+    }
+
+    public static Signature getSignature() throws NoSuchAlgorithmException {
+        return new EdDSAEngine(MessageDigest.getInstance(ed25519.getHashAlgorithm()));
     }
 
     public PublicKey public_key() {

--- a/src/main/java/org/biscuitsec/biscuit/datalog/SymbolTable.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/SymbolTable.java
@@ -180,7 +180,7 @@ public final class SymbolTable implements Serializable {
                     return pk.get().toString();
                 }
         }
-        return "?";
+        return "<"+ scope.publicKey+"?>";
     }
 
     public String print_predicate(final Predicate p) {

--- a/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
@@ -614,8 +614,13 @@ public class Authorizer {
             for (int i = 0; i < this.token.blocks.size(); i++) {
                 Block b = this.token.blocks.get(i);
 
+                SymbolTable blockSymbols = token.symbols;
+                if(b.externalKey.isDefined()) {
+                    blockSymbols = new SymbolTable(b.symbols.symbols, token.symbols.publicKeys());
+                }
+
                 for (int j = 0; j < b.checks.size(); j++) {
-                    checks.add("Block[" + i + "][" + j + "]: " + this.symbols.print_check(b.checks.get(j)));
+                    checks.add("Block[" + (i+1) + "][" + j + "]: " + blockSymbols.print_check(b.checks.get(j)));
                 }
             }
         }

--- a/src/main/java/org/biscuitsec/biscuit/token/ThirdPartyBlockContents.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/ThirdPartyBlockContents.java
@@ -1,0 +1,85 @@
+package org.biscuitsec.biscuit.token;
+
+import biscuit.format.schema.Schema;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.biscuitsec.biscuit.crypto.PublicKey;
+import org.biscuitsec.biscuit.error.Error;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class ThirdPartyBlockContents {
+    byte[] payload;
+    byte[] signature;
+    PublicKey publicKey;
+
+    ThirdPartyBlockContents(byte[] payload, byte[] signature, PublicKey publicKey) {
+        this.payload = payload;
+        this.signature = signature;
+        this.publicKey = publicKey;
+    }
+
+    public Schema.ThirdPartyBlockContents serialize() throws Error.FormatError.SerializationError {
+        Schema.ThirdPartyBlockContents.Builder b = Schema.ThirdPartyBlockContents.newBuilder();
+        b.setPayload(ByteString.copyFrom(this.payload));
+        b.setExternalSignature(b.getExternalSignatureBuilder()
+                .setSignature(ByteString.copyFrom(this.signature))
+                .setPublicKey(this.publicKey.serialize())
+                .build());
+
+        return b.build();
+    }
+
+    static public ThirdPartyBlockContents deserialize(Schema.ThirdPartyBlockContents b) throws Error.FormatError.DeserializationError {
+        byte[] payload = b.getPayload().toByteArray();
+        byte[] signature = b.getExternalSignature().getSignature().toByteArray();
+        PublicKey publicKey = PublicKey.deserialize(b.getExternalSignature().getPublicKey());
+
+        return new ThirdPartyBlockContents(payload, signature, publicKey);
+    }
+
+    static public ThirdPartyBlockContents fromBytes(byte[] slice) throws InvalidProtocolBufferException, Error.FormatError.DeserializationError {
+        return ThirdPartyBlockContents.deserialize(Schema.ThirdPartyBlockContents.parseFrom(slice));
+    }
+
+    public byte[] toBytes() throws IOException, Error.FormatError.SerializationError {
+        Schema.ThirdPartyBlockContents b = this.serialize();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        b.writeTo(stream);
+        return stream.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ThirdPartyBlockContents that = (ThirdPartyBlockContents) o;
+
+        if (!Arrays.equals(payload, that.payload)) return false;
+        if (!Arrays.equals(signature, that.signature)) return false;
+        return Objects.equals(publicKey, that.publicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(payload);
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + (publicKey != null ? publicKey.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ThirdPartyBlockContents{" +
+                "payload=" + Arrays.toString(payload) +
+                ", signature=" + Arrays.toString(signature) +
+                ", publicKey=" + publicKey +
+                '}';
+    }
+}

--- a/src/main/java/org/biscuitsec/biscuit/token/ThirdPartyBlockRequest.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/ThirdPartyBlockRequest.java
@@ -1,0 +1,122 @@
+package org.biscuitsec.biscuit.token;
+
+import biscuit.format.schema.Schema;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+import net.i2p.crypto.eddsa.EdDSAEngine;
+import org.biscuitsec.biscuit.crypto.KeyPair;
+import org.biscuitsec.biscuit.crypto.PublicKey;
+import org.biscuitsec.biscuit.datalog.SymbolTable;
+import org.biscuitsec.biscuit.error.Error;
+import org.biscuitsec.biscuit.token.builder.Block;
+import org.biscuitsec.biscuit.token.format.SerializedBiscuit;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+
+public class ThirdPartyBlockRequest {
+    PublicKey previousKey;
+    List<PublicKey> publicKeys;
+
+    ThirdPartyBlockRequest(PublicKey previousKey, List<PublicKey> publicKeys) {
+        this.previousKey = previousKey;
+        this.publicKeys = publicKeys;
+    }
+
+    public Either<Error.FormatError, ThirdPartyBlockContents> createBlock(KeyPair keyPair, Block blockBuilder) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        SymbolTable symbols = new SymbolTable();
+        for(PublicKey pk: this.publicKeys) {
+            symbols.insert(pk);
+        }
+
+        org.biscuitsec.biscuit.token.Block block = blockBuilder.build(symbols, Option.some(keyPair.public_key()));
+
+        Either<Error.FormatError, byte[]> res = block.to_bytes();
+        if(res.isLeft()) {
+            return Either.left(res.getLeft());
+        }
+
+        byte[] serializedBlock = res.get();
+
+        Signature sgr = KeyPair.generateSignature(keyPair.public_key().algorithm);
+
+        sgr.initSign(keyPair.private_key);
+        sgr.update(serializedBlock);
+
+        ByteBuffer algo_buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        algo_buf.putInt(Integer.valueOf(Schema.PublicKey.Algorithm.Ed25519.getNumber()));
+        algo_buf.flip();
+        sgr.update(algo_buf);
+        sgr.update(previousKey.toBytes());
+        byte[] signature = sgr.sign();
+
+        PublicKey publicKey = keyPair.public_key();
+
+        return Either.right(new ThirdPartyBlockContents(serializedBlock, signature, publicKey));
+    }
+
+    public Schema.ThirdPartyBlockRequest serialize() throws Error.FormatError.SerializationError {
+        Schema.ThirdPartyBlockRequest.Builder b = Schema.ThirdPartyBlockRequest.newBuilder();
+        b.setPreviousKey(this.previousKey.serialize());
+
+        for(PublicKey pk: this.publicKeys) {
+            b.addPublicKeys(pk.serialize());
+        }
+
+        return b.build();
+    }
+
+    static public ThirdPartyBlockRequest deserialize(Schema.ThirdPartyBlockRequest b) throws Error.FormatError.DeserializationError {
+        PublicKey previousKey = PublicKey.deserialize(b.getPreviousKey());
+        List<PublicKey> publicKeys = new ArrayList<>();
+        for(Schema.PublicKey pk: b.getPublicKeysList()) {
+            publicKeys.add(PublicKey.deserialize(pk));
+        }
+        return new ThirdPartyBlockRequest(previousKey, publicKeys);
+    }
+
+    static public ThirdPartyBlockRequest fromBytes(byte[] slice) throws InvalidProtocolBufferException, Error.FormatError.DeserializationError {
+        return ThirdPartyBlockRequest.deserialize(Schema.ThirdPartyBlockRequest.parseFrom(slice));
+    }
+
+    public byte[] toBytes() throws IOException, Error.FormatError.SerializationError {
+        Schema.ThirdPartyBlockRequest b = this.serialize();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        b.writeTo(stream);
+        return stream.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ThirdPartyBlockRequest that = (ThirdPartyBlockRequest) o;
+
+        if (!Objects.equals(previousKey, that.previousKey)) return false;
+        return Objects.equals(publicKeys, that.publicKeys);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = previousKey != null ? previousKey.hashCode() : 0;
+        result = 31 * result + (publicKeys != null ? publicKeys.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ThirdPartyBlockRequest{" +
+                "previousKey=" + previousKey +
+                ", publicKeys=" + publicKeys +
+                '}';
+    }
+}
+

--- a/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
@@ -1,9 +1,12 @@
 package org.biscuitsec.biscuit.token;
 
+import biscuit.format.schema.Schema;
+import net.i2p.crypto.eddsa.EdDSAEngine;
 import org.biscuitsec.biscuit.crypto.KeyDelegate;
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.crypto.PublicKey;
 import org.biscuitsec.biscuit.error.Error;
+import org.biscuitsec.biscuit.token.format.ExternalSignature;
 import org.biscuitsec.biscuit.token.format.SerializedBiscuit;
 import io.vavr.Tuple3;
 import io.vavr.control.Either;
@@ -11,10 +14,9 @@ import io.vavr.control.Option;
 import org.biscuitsec.biscuit.datalog.Check;
 import org.biscuitsec.biscuit.datalog.SymbolTable;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.SignatureException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -129,7 +131,7 @@ public class UnverifiedBiscuit {
      * @return
      */
     public org.biscuitsec.biscuit.token.builder.Block create_block() {
-        return new org.biscuitsec.biscuit.token.builder.Block(1 + this.blocks.size());
+        return new org.biscuitsec.biscuit.token.builder.Block();
     }
 
     /**
@@ -140,7 +142,7 @@ public class UnverifiedBiscuit {
      */
     public UnverifiedBiscuit attenuate(org.biscuitsec.biscuit.token.builder.Block block) throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error {
         SecureRandom rng = new SecureRandom();
-        KeyPair keypair = new KeyPair(rng);
+        KeyPair keypair = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519, rng);
         SymbolTable builderSymbols = new SymbolTable(this.symbols);
         return attenuate(rng, keypair, block.build(builderSymbols));
     }
@@ -165,7 +167,7 @@ public class UnverifiedBiscuit {
             throw new Error.SymbolTableOverlap();
         }
 
-        Either<Error.FormatError, SerializedBiscuit> containerRes = copiedBiscuit.serializedBiscuit.append(keypair, block);
+        Either<Error.FormatError, SerializedBiscuit> containerRes = copiedBiscuit.serializedBiscuit.append(keypair, block, Option.none());
         if (containerRes.isLeft()) {
             throw containerRes.getLeft();
         }
@@ -232,6 +234,95 @@ public class UnverifiedBiscuit {
         return this.root_key_id;
     }
 
+    /**
+     * Generates a third party block request from a token
+     */
+    public ThirdPartyBlockRequest thirdPartyRequest() {
+        PublicKey previousKey;
+        if(this.serializedBiscuit.blocks.isEmpty()) {
+            previousKey = this.serializedBiscuit.authority.key;
+        } else {
+            previousKey = this.serializedBiscuit.blocks.get(this.serializedBiscuit.blocks.size() - 1).key;
+        }
+
+        List<PublicKey> publicKeys = new ArrayList<>(this.symbols.publicKeys());
+        return new ThirdPartyBlockRequest(previousKey, publicKeys);
+    }
+
+
+    /**
+     * Generates a third party block request from a token
+     */
+    public UnverifiedBiscuit appendThirdPartyBlock(PublicKey externalKey, ThirdPartyBlockContents blockResponse)
+            throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error {
+        KeyPair nextKeyPair = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519);
+
+        Signature sgr = KeyPair.generateSignature(externalKey.algorithm);
+        sgr.initVerify(externalKey.key);
+
+        sgr.update(blockResponse.payload);
+        ByteBuffer algo_buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+        algo_buf.putInt(Integer.valueOf(Schema.PublicKey.Algorithm.Ed25519.getNumber()));
+        algo_buf.flip();
+        sgr.update(algo_buf);
+
+        PublicKey previousKey;
+        if(this.serializedBiscuit.blocks.isEmpty()) {
+            previousKey = this.serializedBiscuit.authority.key;
+        } else {
+            previousKey = this.serializedBiscuit.blocks.get(this.serializedBiscuit.blocks.size() - 1).key;
+        }
+        sgr.update(previousKey.toBytes());
+        if (!sgr.verify(blockResponse.signature)) {
+            throw new Error.FormatError.Signature.InvalidSignature("signature error: Verification equation was not satisfied");
+        }
+
+        Either<Error.FormatError, Block> res = Block.from_bytes(blockResponse.payload, Option.some(externalKey));
+        if(res.isLeft()) {
+            throw res.getLeft();
+        }
+
+        Block block = res.get();
+
+        ExternalSignature externalSignature = new ExternalSignature(externalKey, blockResponse.signature);
+
+        UnverifiedBiscuit copiedBiscuit = this.copy();
+
+        Either<Error.FormatError, SerializedBiscuit> containerRes = copiedBiscuit.serializedBiscuit.append(nextKeyPair, block, Option.some(externalSignature));
+        if (containerRes.isLeft()) {
+            throw containerRes.getLeft();
+        }
+
+        SerializedBiscuit container = containerRes.get();
+
+        SymbolTable symbols = new SymbolTable(copiedBiscuit.symbols);
+
+        ArrayList<Block> blocks = new ArrayList<>();
+        for (Block b : copiedBiscuit.blocks) {
+            blocks.add(b);
+        }
+        blocks.add(block);
+
+        for(PublicKey pk: block.publicKeys) {
+            symbols.insert(pk);
+        }
+
+        long pkIndex = symbols.insert(externalKey);
+
+        HashMap<Long, List<Long>> publicKeyToBlockId = new HashMap<>();
+        publicKeyToBlockId.putAll(this.publicKeyToBlockId);
+        if(publicKeyToBlockId.containsKey(pkIndex)) {
+            publicKeyToBlockId.get(pkIndex).add((long)this.blocks.size()+1);
+        } else {
+            List<Long> list = new ArrayList<>();
+            list.add((long)this.blocks.size()+1);
+            publicKeyToBlockId.put(pkIndex, list);
+        }
+
+        List<byte[]> revocation_ids = container.revocation_identifiers();
+
+        return new UnverifiedBiscuit(copiedBiscuit.authority, blocks, symbols, container, publicKeyToBlockId, revocation_ids);
+    }
 
     /**
      * Prints a token's content

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/Block.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/Block.java
@@ -18,15 +18,13 @@ import static org.biscuitsec.biscuit.token.builder.Utils.*;
 import java.util.*;
 
 public class Block {
-    long index;
     String context;
     List<Fact> facts;
     List<Rule> rules;
     List<Check> checks;
     List<Scope> scopes;
 
-    public Block(long index) {
-        this.index = index;
+    public Block() {
         this.context = "";
         this.facts = new ArrayList<>();
         this.rules = new ArrayList<>();
@@ -138,7 +136,6 @@ public class Block {
             block_symbols.add(symbols.symbols.get(i));
         }
 
-
         List<PublicKey> publicKeys = new ArrayList<>();
         for (int i = publicKeyStart; i < symbols.currentPublicKeyOffset(); i++) {
             publicKeys.add(symbols.publicKeys().get(i));
@@ -155,7 +152,6 @@ public class Block {
 
         Block block = (Block) o;
 
-        if (index != block.index) return false;
         if (!Objects.equals(context, block.context)) return false;
         if (!Objects.equals(facts, block.facts)) return false;
         if (!Objects.equals(rules, block.rules)) return false;
@@ -165,8 +161,7 @@ public class Block {
 
     @Override
     public int hashCode() {
-        int result = (int) (index ^ (index >>> 32));
-        result = 31 * result + (context != null ? context.hashCode() : 0);
+        int result = context != null ? context.hashCode() : 0;
         result = 31 * result + (facts != null ? facts.hashCode() : 0);
         result = 31 * result + (rules != null ? rules.hashCode() : 0);
         result = 31 * result + (checks != null ? checks.hashCode() : 0);

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
@@ -28,7 +28,7 @@ public class Parser {
      * @return Either<Map<Integer, List<Error>>, Block>
      */
     public static Either<Map<Integer, List<Error>>, Block> datalog(long index, String s) {
-        Block blockBuilder = new Block(index);
+        Block blockBuilder = new Block();
 
         // empty block code
         if (s.isEmpty()) {

--- a/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/BuilderTest.java
@@ -28,7 +28,7 @@ public class BuilderTest {
         KeyPair root = new KeyPair(rng);
         SymbolTable symbols = Biscuit.default_symbol_table();
 
-        Block authority_builder = new Block(0);
+        Block authority_builder = new Block();
         authority_builder.add_fact(Utils.fact("revocation_id", Arrays.asList(Utils.date(Date.from(Instant.now())))));
         authority_builder.add_fact(Utils.fact("right", Arrays.asList(Utils.s("admin"))));
         authority_builder.add_rule(Utils.constrained_rule("right",

--- a/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
@@ -434,7 +434,7 @@ class ParserTest {
         Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
         assertTrue(output.isRight());
 
-        Block validBlock = new Block(1);
+        Block validBlock = new Block();
         validBlock.add_fact(l1);
         validBlock.add_fact(l2);
         validBlock.add_rule(l3);
@@ -455,7 +455,7 @@ class ParserTest {
         Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
         assertTrue(output.isRight());
 
-        Block validBlock = new Block(1);
+        Block validBlock = new Block();
         validBlock.add_check(l1);
 
         output.forEach(block ->
@@ -473,7 +473,7 @@ class ParserTest {
         Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1,  toParse);
         assertTrue(output.isRight());
 
-        Block validBlock = new Block(1);
+        Block validBlock = new Block();
         validBlock.add_check(l1);
 
         output.forEach(block ->

--- a/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
@@ -38,7 +38,7 @@ public class BiscuitTest {
 
         KeyPair root = new KeyPair(rng);
 
-        Block authority_builder = new Block(0);
+        Block authority_builder = new Block();
 
         authority_builder.add_fact(fact("right", Arrays.asList(s("file1"), s("read"))));
         authority_builder.add_fact(fact("right", Arrays.asList(s("file2"), s("read"))));
@@ -226,7 +226,7 @@ public class BiscuitTest {
         SecureRandom rng = new SecureRandom();
         KeyPair root = new KeyPair(rng);
 
-        Block authority_builder = new Block(0);
+        Block authority_builder = new Block();
         Date date = Date.from(Instant.now());
         authority_builder.add_fact(fact("revocation_id", Arrays.asList(date(date))));
 
@@ -369,7 +369,7 @@ public class BiscuitTest {
 
         KeyPair root = new KeyPair(rng);
 
-        Block authority_builder = new Block(0);
+        Block authority_builder = new Block();
 
         authority_builder.add_fact(fact("namespace:right", Arrays.asList(s("file1"), s("read"))));
         authority_builder.add_fact(fact("namespace:right", Arrays.asList(s("file1"), s("write"))));
@@ -616,7 +616,7 @@ public class BiscuitTest {
 
         KeyPair root = new KeyPair(rng);
 
-        Block authority_builder = new Block(0);
+        Block authority_builder = new Block();
 
         authority_builder.add_fact(fact("right", Arrays.asList(s("file1"), s("read"))));
         authority_builder.add_fact(fact("right", Arrays.asList(s("file2"), s("read"))));

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -18,6 +18,7 @@ import org.biscuitsec.biscuit.token.builder.Check;
 import org.biscuitsec.biscuit.token.builder.Expression;
 import org.biscuitsec.biscuit.token.builder.parser.ExpressionParser;
 import org.biscuitsec.biscuit.token.builder.parser.Parser;
+import org.biscuitsec.biscuit.token.format.SerializedBiscuit;
 import org.biscuitsec.biscuit.token.format.SignedBlock;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -78,14 +79,24 @@ class SamplesTest {
             sampleSymbols = new SymbolTable(baseSymbols);
         } else {
             sampleSymbols = new SymbolTable();
+
+            for(PublicKey pk: baseSymbols.publicKeys()) {
+               sampleSymbols.insert(pk);
+            }
         }
 
         org.biscuitsec.biscuit.token.Block generatedSampleBlock = outputSample.get().build(sampleSymbols);
-        System.out.println(generatedSampleBlock.symbols.symbols);
-        System.out.println(block.symbols.symbols);
-        System.out.println(sampleSymbols.symbols);
+
         if(!block.externalKey.isDefined()) {
             generatedSampleBlock.symbols.symbols.forEach(baseSymbols::add);
+        } else {
+            generatedSampleBlock.setExternalKey(block.externalKey.get());
+            generatedSampleBlock.version = SerializedBiscuit.MAX_SCHEMA_VERSION;
+            baseSymbols.insert(block.externalKey.get());
+        }
+
+        for(PublicKey pk: generatedSampleBlock.publicKeys) {
+            baseSymbols.insert(pk);
         }
         System.out.println(baseSymbols.symbols);
 

--- a/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ThirdPartyTest.java
@@ -1,0 +1,220 @@
+package org.biscuitsec.biscuit.token;
+
+import org.biscuitsec.biscuit.crypto.KeyPair;
+import org.biscuitsec.biscuit.datalog.RunLimits;
+import org.biscuitsec.biscuit.error.Error;
+import org.biscuitsec.biscuit.error.FailedCheck;
+import org.biscuitsec.biscuit.error.LogicError;
+import org.biscuitsec.biscuit.token.builder.Block;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.SignatureException;
+import java.time.Duration;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ThirdPartyTest {
+    @Test
+    public void testRoundTrip() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error, IOException {
+        byte[] seed = {0, 0, 0, 0};
+        SecureRandom rng = new SecureRandom(seed);
+
+        System.out.println("preparing the authority block");
+
+        KeyPair root = new KeyPair(rng);
+        KeyPair external = new KeyPair(rng);
+        System.out.println("external: ed25519/"+external.public_key().toHex());
+
+        Block authority_builder = new Block();
+        authority_builder.add_fact("right(\"read\")");
+        authority_builder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+
+        Biscuit b1 = Biscuit.make(rng, root, authority_builder.build());
+        ThirdPartyBlockRequest request = b1.thirdPartyRequest();
+        byte[] reqb = request.toBytes();
+        ThirdPartyBlockRequest reqdeser = ThirdPartyBlockRequest.fromBytes(reqb);
+        assertEquals(request, reqdeser);
+
+        Block builder = new Block();
+        builder.add_fact("group(\"admin\")");
+        builder.add_check("check if resource(\"file1\")");
+
+        ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).get();
+        byte[] resb = blockResponse.toBytes();
+        ThirdPartyBlockContents resdeser = ThirdPartyBlockContents.fromBytes(resb);
+        assertEquals(blockResponse, resdeser);
+
+        Biscuit b2 = b1.appendThirdPartyBlock(external.public_key(), blockResponse);
+
+        byte[] data = b2.serialize();
+        Biscuit deser = Biscuit.from_bytes(data, root.public_key());
+        assertEquals(b2.print(), deser.print());
+
+        System.out.println("will check the token for resource=file1");
+        Authorizer authorizer = deser.authorizer();
+        authorizer.add_fact("resource(\"file1\")");
+        authorizer.add_policy("allow if true");
+        authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+
+        System.out.println("will check the token for resource=file2");
+        Authorizer authorizer2 = deser.authorizer();
+        authorizer2.add_fact("resource(\"file2\")");
+        authorizer2.add_policy("allow if true");
+
+        try {
+            authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+        } catch (Error e) {
+            System.out.println(e);
+            assertEquals(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                            new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
+                    ))),
+                    e);
+        }
+    }
+
+    @Test
+    public void testPublicKeyInterning() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error {
+        byte[] seed = {0, 0, 0, 0};
+        SecureRandom rng = new SecureRandom(seed);
+
+        System.out.println("preparing the authority block");
+
+        KeyPair root = new KeyPair(rng);
+        KeyPair external1 = new KeyPair(rng);
+        KeyPair external2 = new KeyPair(rng);
+        KeyPair external3 = new KeyPair(rng);
+        //System.out.println("external: ed25519/"+external.public_key().toHex());
+
+        Block authority_builder = new Block();
+        authority_builder.add_fact("right(\"read\")");
+        authority_builder.add_check("check if first(\"admin\") trusting ed25519/"+external1.public_key().toHex());
+
+        org.biscuitsec.biscuit.token.Block authority_block =  authority_builder.build();
+        System.out.println(authority_block);
+        Biscuit b1 = Biscuit.make(rng, root, authority_block);
+        System.out.println("TOKEN: "+b1.print());
+
+        ThirdPartyBlockRequest request1 = b1.thirdPartyRequest();
+        Block builder = new Block();
+        builder.add_fact("first(\"admin\")");
+        builder.add_fact("second(\"A\")");
+        builder.add_check("check if third(3) trusting ed25519/"+external2.public_key().toHex());
+        ThirdPartyBlockContents blockResponse = request1.createBlock(external1, builder).get();
+        Biscuit b2 = b1.appendThirdPartyBlock(external1.public_key(), blockResponse);
+        byte[] data = b2.serialize();
+        Biscuit deser2 = Biscuit.from_bytes(data, root.public_key());
+        assertEquals(b2.print(), deser2.print());
+        System.out.println("TOKEN: "+deser2.print());
+
+        ThirdPartyBlockRequest request2 = deser2.thirdPartyRequest();
+        Block builder2 = new Block();
+        builder2.add_fact("third(3)");
+        builder2.add_check("check if fourth(1) trusting ed25519/"+external3.public_key().toHex()+", ed25519/"+external1.public_key().toHex());
+        ThirdPartyBlockContents blockResponse2 = request2.createBlock(external2, builder2).get();
+        Biscuit b3 = deser2.appendThirdPartyBlock(external2.public_key(), blockResponse2);
+        byte[] data2 = b3.serialize();
+        Biscuit deser3 = Biscuit.from_bytes(data2, root.public_key());
+        assertEquals(b3.print(), deser3.print());
+        System.out.println("TOKEN: "+deser3.print());
+
+
+        ThirdPartyBlockRequest request3 = deser3.thirdPartyRequest();
+        Block builder3 = new Block();
+        builder3.add_fact("fourth(1)");
+        builder3.add_check("check if resource(\"file1\")");
+        ThirdPartyBlockContents blockResponse3 = request3.createBlock(external1, builder3).get();
+        Biscuit b4 = deser3.appendThirdPartyBlock(external1.public_key(), blockResponse3);
+        byte[] data3 = b4.serialize();
+        Biscuit deser4 = Biscuit.from_bytes(data3, root.public_key());
+        assertEquals(b4.print(), deser4.print());
+        System.out.println("TOKEN: "+deser4.print());
+
+
+        System.out.println("will check the token for resource=file1");
+        Authorizer authorizer = deser4.authorizer();
+        authorizer.add_fact("resource(\"file1\")");
+        authorizer.add_policy("allow if true");
+        System.out.println("Authorizer world:\n"+authorizer.print_world());
+        authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+
+        System.out.println("will check the token for resource=file2");
+        Authorizer authorizer2 = deser4.authorizer();
+        authorizer2.add_fact("resource(\"file2\")");
+        authorizer2.add_policy("allow if true");
+        System.out.println("Authorizer world 2:\n"+authorizer2.print_world());
+
+        try {
+            authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+        } catch (Error e) {
+            System.out.println(e);
+            assertEquals(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                            new FailedCheck.FailedBlock(3, 0, "check if resource(\"file1\")")
+                    ))),
+                    e);
+        }
+    }
+
+    @Test
+    public void testReusedSymbols() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, CloneNotSupportedException, Error {
+        byte[] seed = {0, 0, 0, 0};
+        SecureRandom rng = new SecureRandom(seed);
+
+        System.out.println("preparing the authority block");
+
+        KeyPair root = new KeyPair(rng);
+        KeyPair external = new KeyPair(rng);
+        System.out.println("external: ed25519/"+external.public_key().toHex());
+
+        Block authority_builder = new Block();
+        authority_builder.add_fact("right(\"read\")");
+        authority_builder.add_check("check if group(\"admin\") trusting ed25519/"+external.public_key().toHex());
+
+        Biscuit b1 = Biscuit.make(rng, root, authority_builder.build());
+        ThirdPartyBlockRequest request = b1.thirdPartyRequest();
+        Block builder = new Block();
+        builder.add_fact("group(\"admin\")");
+        builder.add_fact("resource(\"file2\")");
+        builder.add_check("check if resource(\"file1\")");
+        builder.add_check("check if right(\"read\")");
+
+        ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).get();
+        Biscuit b2 = b1.appendThirdPartyBlock(external.public_key(), blockResponse);
+
+        byte[] data = b2.serialize();
+        Biscuit deser = Biscuit.from_bytes(data, root.public_key());
+        assertEquals(b2.print(), deser.print());
+
+        System.out.println("will check the token for resource=file1");
+        Authorizer authorizer = deser.authorizer();
+        authorizer.add_fact("resource(\"file1\")");
+        authorizer.add_policy("allow if true");
+        authorizer.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+        System.out.println("Authorizer world:\n"+authorizer.print_world());
+
+
+        System.out.println("will check the token for resource=file2");
+        Authorizer authorizer2 = deser.authorizer();
+        authorizer2.add_fact("resource(\"file2\")");
+        authorizer2.add_policy("allow if true");
+
+        try {
+            authorizer2.authorize(new RunLimits(500, 100, Duration.ofMillis(500)));
+        } catch (Error e) {
+            System.out.println(e);
+            assertEquals(
+                    new Error.FailedLogic(new LogicError.Unauthorized(new LogicError.MatchedPolicy.Allow(0), Arrays.asList(
+                            new FailedCheck.FailedBlock(1, 0, "check if resource(\"file1\")")
+                    ))),
+                    e);
+        }
+    }
+}
+


### PR DESCRIPTION
This implements 3rd party block generation and appending to existing tokens. It also fixes existing issues with public key interning which made deserialization of tokens with 3rd party blocks incorrect in some cases.